### PR TITLE
adding proxy for docker service

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,11 +44,40 @@
     update_cache: True
 
 - name: create docker environment file
+  when: docker_http_proxy is defined or docker_https_proxy is defined
   template:
     src: sysconfig/docker
     dest: /etc/sysconfig/docker
+    owner: root
+    group: docker
+    mode: 0644
     force: True
-  when: proxy_env is defined
+  notify:
+    - restart docker
+
+- name: create a systemd drop-in directory for the docker service 
+  file:
+    path: /etc/systemd/system/docker.service.d
+    owner: root
+    group: docker
+    mode: 0755
+    state: directory
+  when: docker_http_proxy is defined or docker_https_proxy is defined
+  tags:
+    - template
+
+- name: create the proxy config for the docker service
+  when: docker_http_proxy is defined or docker_https_proxy is defined
+  template:
+    src: http-proxy.conf
+    dest: /etc/systemd/system/docker.service.d/
+    owner: root
+    group: docker
+    mode: 0644
+  notify:
+    - restart docker
+  tags:
+    - template
 
 - name: create service in systemd
   template:

--- a/templates/http-proxy.conf
+++ b/templates/http-proxy.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="HTTP_PROXY={{ docker_http_proxy }}" "HTTPS_PROXY={{ docker_https_proxy }}" "NO_PROXY={{ docker_no_proxy }}"

--- a/templates/sysconfig/docker
+++ b/templates/sysconfig/docker
@@ -1,5 +1,9 @@
-{% if proxy_env.https_proxy is defined %}
-HTTP_PROXY="{{ proxy_env.http_proxy }}"
-HTTPS_PROXY="{{ proxy_env.https_proxy }}"
-NO_PROXY="{{ proxy_env.no_proxy }}"
+{% if docker_http_proxy is defined %}
+http_proxy={{ docker_http_proxy }}
+{% endif %}
+{% if docker_https_proxy is defined %}
+http_proxy={{ docker_https_proxy }}
+{% endif %}
+{% if docker_no_proxy is defined %}
+no_proxy={{ docker_no_proxy }}
 {% endif %}


### PR DESCRIPTION
HTTP_PROXY etc,. should not be defined in all nooks and cradles. Instead each docker daemon should know its way out. This PR adds the proxy config is these vars exist:

- docker_http_proxy
- docker_https_proxy
- docker_no_proxy