### PR TITLE
Fixes docker startup issue 2021-03-29

### DIFF
--- a/templates/daemon.json
+++ b/templates/daemon.json
@@ -1,5 +1,4 @@
 {
-    "log-driver": "journald",
     "bip": "10.20.0.1/16",
     "fixed-cidr": "10.20.0.0/16",
     "fixed-cidr-v6": "2001:db8::/64",


### PR DESCRIPTION
dockerd-current[19842]: unable to configure the Docker daemon with file /etc/docker/daemon.json: the following directives are specified both as a flag and in the configuration file: log-driver: (from flag: journald, from file: journald)